### PR TITLE
[Feat] 포트폴리오 관련 기능 추가

### DIFF
--- a/goormton_univ/src/main/java/goormton/univ/portfolio/Portfolio.java
+++ b/goormton_univ/src/main/java/goormton/univ/portfolio/Portfolio.java
@@ -1,4 +1,0 @@
-package goormton.univ.portfolio;
-
-public class Portfolio {
-}

--- a/goormton_univ/src/main/java/goormton/univ/portfolio/controller/PortfolioController.java
+++ b/goormton_univ/src/main/java/goormton/univ/portfolio/controller/PortfolioController.java
@@ -1,0 +1,64 @@
+package goormton.univ.portfolio.controller;
+
+import goormton.univ.portfolio.dto.PortfolioCreateDto;
+import goormton.univ.portfolio.dto.PortfolioResponseDto;
+import goormton.univ.portfolio.dto.PortfolioUpdateDto;
+import goormton.univ.portfolio.service.PdfGenerator;
+import goormton.univ.portfolio.service.PortfolioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/portfolios")
+public class PortfolioController {
+
+    private final PortfolioService portfolioService;
+    private final PdfGenerator pdfGenerator;
+
+    // 포트폴리오 조회
+    @GetMapping("/{portfolioId}")
+    public ResponseEntity<PortfolioResponseDto> getPortfolio(@PathVariable Long portfolioId) {
+        PortfolioResponseDto portfolio = portfolioService.findById(portfolioId);
+        return ResponseEntity.ok(portfolio);
+    }
+
+    // 포트폴리오 수정
+    @PutMapping("/{portfolioId}")
+    public ResponseEntity<Void> updatePortfolio(@PathVariable Long portfolioId,
+                                                @RequestBody PortfolioUpdateDto request) {
+        portfolioService.update(portfolioId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 포트폴리오 삭제
+    @DeleteMapping("/{portfolioId}")
+    public ResponseEntity<Void> deletePortfolio(@PathVariable Long portfolioId) {
+        portfolioService.delete(portfolioId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // 포트폴리오 생성
+    @PostMapping
+    public ResponseEntity<Long> createPortfolio(@RequestBody PortfolioCreateDto portfolioCreateDto) {
+        Long createdId = portfolioService.create(portfolioCreateDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdId);
+    }
+
+    // 포트폴리오 PDF 다운로드 (추후 수정 가능)
+    @GetMapping("/{portfolioId}/export")
+    public ResponseEntity<ByteArrayResource> exportPdf(@PathVariable Long portfolioId) {
+        byte[] pdfBytes = pdfGenerator.generatePortfolioPdf(portfolioId);
+        String fileName = "portfolio.pdf";
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName)
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(new ByteArrayResource(pdfBytes));
+    }
+}

--- a/goormton_univ/src/main/java/goormton/univ/portfolio/dto/PortfolioCreateDto.java
+++ b/goormton_univ/src/main/java/goormton/univ/portfolio/dto/PortfolioCreateDto.java
@@ -1,0 +1,9 @@
+package goormton.univ.portfolio.dto;
+
+import goormton.univ.portfolio.entity.Portfolio;
+import lombok.Getter;
+
+@Getter
+public class PortfolioCreateDto {
+    private String portfolioText;
+}

--- a/goormton_univ/src/main/java/goormton/univ/portfolio/dto/PortfolioResponseDto.java
+++ b/goormton_univ/src/main/java/goormton/univ/portfolio/dto/PortfolioResponseDto.java
@@ -1,0 +1,17 @@
+package goormton.univ.portfolio.dto;
+
+import goormton.univ.portfolio.entity.Portfolio;
+import lombok.Getter;
+
+@Getter
+public class PortfolioResponseDto {
+    private Long portfolioId;
+    private String portfolioText;
+
+    public static PortfolioResponseDto fromEntity(Portfolio portfolio) {
+        PortfolioResponseDto portfolioResponseDto = new PortfolioResponseDto();
+        portfolioResponseDto.portfolioId = portfolio.getPortfolioId();
+        portfolioResponseDto.portfolioText = portfolio.getPortfolioText();
+        return portfolioResponseDto;
+    }
+}

--- a/goormton_univ/src/main/java/goormton/univ/portfolio/dto/PortfolioUpdateDto.java
+++ b/goormton_univ/src/main/java/goormton/univ/portfolio/dto/PortfolioUpdateDto.java
@@ -1,0 +1,8 @@
+package goormton.univ.portfolio.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PortfolioUpdateDto {
+    private String portfolioText;
+}

--- a/goormton_univ/src/main/java/goormton/univ/portfolio/entity/Portfolio.java
+++ b/goormton_univ/src/main/java/goormton/univ/portfolio/entity/Portfolio.java
@@ -1,0 +1,40 @@
+package goormton.univ.portfolio.entity;
+
+import goormton.univ.portfolio.dto.PortfolioCreateDto;
+import goormton.univ.portfolio.dto.PortfolioUpdateDto;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Portfolio {
+    @Id
+    @GeneratedValue
+    private Long portfolioId;
+
+    private String portfolioText;
+
+    @Lob
+    private String contentJson;
+
+    private LocalDateTime createdAt;
+
+    public static Portfolio from(PortfolioCreateDto dto) {
+        return Portfolio.builder()
+                .portfolioText(dto.getPortfolioText())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void updatePortfolio(PortfolioUpdateDto portfolioUpdateDto) {
+        this.portfolioText = portfolioUpdateDto.getPortfolioText();
+    }
+}

--- a/goormton_univ/src/main/java/goormton/univ/portfolio/repository/ProtfolioRepository.java
+++ b/goormton_univ/src/main/java/goormton/univ/portfolio/repository/ProtfolioRepository.java
@@ -1,0 +1,7 @@
+package goormton.univ.portfolio.repository;
+
+import goormton.univ.portfolio.entity.Portfolio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProtfolioRepository extends JpaRepository<Portfolio, Long> {
+}

--- a/goormton_univ/src/main/java/goormton/univ/portfolio/service/PdfGenerator.java
+++ b/goormton_univ/src/main/java/goormton/univ/portfolio/service/PdfGenerator.java
@@ -1,0 +1,61 @@
+package goormton.univ.portfolio.service;
+
+import goormton.univ.portfolio.entity.Portfolio;
+import goormton.univ.portfolio.repository.ProtfolioRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+
+import java.io.ByteArrayOutputStream;
+
+@Component
+@RequiredArgsConstructor
+public class PdfGenerator {
+
+    private final ProtfolioRepository portfolioRepository;
+
+    public byte[] generatePortfolioPdf(Long portfolioId) {
+        Portfolio portfolio = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 포트폴리오가 존재하지 않습니다."));
+
+        String htmlContent = generateHtmlFromPortfolio(portfolio);
+        try {
+            return generatePdfFromHtml(htmlContent);
+        } catch (Exception e) {
+            throw new RuntimeException("PDF 변환 중 오류 발생", e);
+        }
+    }
+
+    // HTML을 PDF로 변환
+    public byte[] generatePdfFromHtml(String htmlContent) {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+            ITextRenderer renderer = new ITextRenderer();
+            renderer.setDocumentFromString(htmlContent);
+            renderer.layout();
+            renderer.createPDF(os);
+            return os.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException("PDF 생성 실패", e);
+        }
+    }
+
+    // HTML 생성 함수
+    private String generateHtmlFromPortfolio(Portfolio portfolio) {
+        return """
+            <html>
+                <head>
+                    <style>
+                        body { font-family: 'Arial', sans-serif; padding: 20px; }
+                        h1 { color: #333; }
+                        p { font-size: 14px; }
+                    </style>
+                </head>
+                <body>
+                    <h1>포트폴리오</h1>
+                    <p>%s</p>
+                </body>
+            </html>
+            """.formatted(portfolio.getPortfolioText());
+    }
+}

--- a/goormton_univ/src/main/java/goormton/univ/portfolio/service/PortfolioService.java
+++ b/goormton_univ/src/main/java/goormton/univ/portfolio/service/PortfolioService.java
@@ -1,0 +1,14 @@
+package goormton.univ.portfolio.service;
+
+import goormton.univ.portfolio.dto.PortfolioCreateDto;
+import goormton.univ.portfolio.dto.PortfolioResponseDto;
+import goormton.univ.portfolio.dto.PortfolioUpdateDto;
+import org.springframework.stereotype.Service;
+
+public interface PortfolioService {
+    PortfolioResponseDto findById(Long id);
+    void update(Long id, PortfolioUpdateDto request);
+    void delete(Long id);
+    Long create(PortfolioCreateDto portfolioCreateDto);
+
+}

--- a/goormton_univ/src/main/java/goormton/univ/portfolio/service/PortfolioServiceImpl.java
+++ b/goormton_univ/src/main/java/goormton/univ/portfolio/service/PortfolioServiceImpl.java
@@ -1,0 +1,44 @@
+package goormton.univ.portfolio.service;
+
+import goormton.univ.portfolio.dto.PortfolioCreateDto;
+import goormton.univ.portfolio.dto.PortfolioResponseDto;
+import goormton.univ.portfolio.dto.PortfolioUpdateDto;
+import goormton.univ.portfolio.entity.Portfolio;
+import goormton.univ.portfolio.repository.ProtfolioRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.io.ByteArrayOutputStream;
+import org.xhtmlrenderer.pdf.ITextRenderer;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioServiceImpl implements PortfolioService {
+
+    private final ProtfolioRepository portfolioRepository;
+
+    @Override
+    public PortfolioResponseDto findById(Long id) {
+        Portfolio portfolio = portfolioRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("포트폴리오가 존재하지 않습니다."));
+        return PortfolioResponseDto.fromEntity(portfolio);
+    }
+
+    @Override
+    public void update(Long id, PortfolioUpdateDto portfolioUpdateDto) {
+        Portfolio portfolio = portfolioRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("포트폴리오가 존재하지 않습니다."));
+        portfolio.updatePortfolio(portfolioUpdateDto);
+    }
+
+    @Override
+    public void delete(Long portfolioId) {
+        portfolioRepository.deleteById(portfolioId);
+    }
+
+    @Override
+    public Long create(PortfolioCreateDto portfolioCreateDto) {
+        Portfolio portfolio = Portfolio.from(portfolioCreateDto);
+        return portfolioRepository.save(portfolio).getPortfolioId();
+    }
+}


### PR DESCRIPTION
### 추가한 기능
- 포트폴리오 CRUD 기능 (POST /api/portfolios, GET /api/portfolios/{portfolioId}, PUT /api/portfolios/{portfolioId}, DELETE /api/portfolios/{portfolioId})
- 포트폴리오 pdf로 다운로드 기능
  - postman에서도 테스트 가능
  - 원리:
    - Portfolio (DB 조회) 
    - `generateHtmlFromPortfolio`: HTML 문자열 생성 
    - `generatePdfFromHtml`: HTML → PDF 변환 
    - `generatePortfolioPdf`: byte[] 로 반환 (→ HTTP 응답)

### 추후 수정사항
- 포트폴리오 기능 구체화에 따른 포트폴리오 필드 수정
- user와 포트폴리오 연결
- 로그인/회원가입 기능 구현 이후 사용자 인증 부분 추가 예정
- 현재, portfolioText로 영어만 가능 -> 한글로 확장 예정